### PR TITLE
Spelling fixes for Deadline

### DIFF
--- a/actions.zil
+++ b/actions.zil
@@ -2915,7 +2915,7 @@ perhaps angry -- you can't be sure." CR>)
 		       <TELL
 "Through the grimy window you see Mr. Baxter and Ms. Dunbar talking. Dunbar
 is doing most of the talking, barely restraining tears. Baxter is listening,
-nodding grimly, and occassionally saying a few words. Unfortunately, you can't
+nodding grimly, and occasionally saying a few words. Unfortunately, you can't
 make any of them out." CR>)
 		      (T
 		       <TELL

--- a/actions.zil
+++ b/actions.zil
@@ -1359,7 +1359,7 @@ about a new will. Maybe the old man just wanted to change something.\"" CR>)
 		       <TELL
 "\"Like I told your detective friend yesterday, we didn't get along too well.
 He was always riding me, giving me a hard time.\" George gets worked up
-talking about it.\"Look, man. I'm not going to lie and say I loved him, right?
+talking about it. \"Look, man. I'm not going to lie and say I loved him, right?
 He got what...\" He stops in mid-sentence." CR>)
 		      (<==? ,PRSI ,GLOBAL-FOCUS>
 		       <TELL

--- a/actions.zil
+++ b/actions.zil
@@ -3761,7 +3761,7 @@ head at close range, leaving a most distasteful mess." CR>)
 	 <MOVE ,BAXTER ,SOUTH-LAWN>
 	 <COND (<==? ,HERE ,SOUTH-LAWN>
 		<TELL
-"A limosine pulls up the drive. Mr. Baxter exits and the limo pulls away.
+"A limousine pulls up the drive. Mr. Baxter exits and the limo pulls away.
 Baxter takes a deep breath and looks around." CR>)
 	       (<OR <EQUAL? ,HERE ,FRONT-PATH ,EAST-LAWN ,WEST-LAWN>
 		    <EQUAL? ,HERE ,EAST-OF-DOOR ,WEST-OF-DOOR>>

--- a/actions.zil
+++ b/actions.zil
@@ -945,7 +945,7 @@ He hesitates suddenly, pen in hand." CR>
 		       <TELL
 "\"A fascinating story, Inspector. A man is found dead behind a locked door,
 a clear suicide. Yet the detective seems bent on proving that a murder has
-occured. Rather odd, wouldn't you say?\"" CR>)
+occurred. Rather odd, wouldn't you say?\"" CR>)
 		      (<==? ,PRSI ,GLOBAL-CONCERT>
 		       <TELL
 "\"A marvelous concert! There were works by Beethoven, Sibelius, and Ravel. I

--- a/actions.zil
+++ b/actions.zil
@@ -1026,7 +1026,7 @@ life here. I am quite grieved for her.\"" CR>)
 		      (<OR <EQUAL? ,PRSI ,ROURKE ,GLOBAL-ROURKE>
 			   <EQUAL? ,PRSI ,GARDENER ,GLOBAL-GARDENER>>
 		       <TELL
-"\"I don't know much about " D ,PRSI "\"." CR>)
+"\"I don't know much about " D ,PRSI ".\"" CR>)
 		      (<EQUAL? ,PRSI ,GLOBAL-OLD-WILL>
 		       <TELL
 "\"I really don't know anything about the old will.\"" CR>)
@@ -2781,17 +2781,17 @@ those of Mr. Robner and Ms. Dunbar">)
 	       (<==? ,FINGERPRINT-OBJ ,SUGAR-BOWL>
 		<TELL "\"The bowl,\" he begins,
 \"has the fingerprints of Mr. Robner and Ms. Dunbar. The bowl
-contains common table sugar only.">)
+contains common table sugar only">)
 	       (T
 		<TELL "\"I am sorry,\" he begins,
-\" but the lab found nothing of interest.">)>
+\"but the lab found nothing of interest">)>
 	 <COND (<AND <EQUAL? ,FINGERPRINT-OBJ ,LADDER>
 		     <NOT <==? <GETP ,HERE ,P?LINE> ,OUTSIDE-LINE-C>>>
 		<TELL " In the interests of
 civility, I have left the ladder outside the house.\" He leaves." CR>
 		<MOVE ,LADDER ,FRONT-PATH>)
 	       (T
-		<TELL "\".
+		<TELL ".\"
 With that, he leaves, handing you the " D ,FINGERPRINT-OBJ
 					" as he whisks away." CR>
 		<MOVE ,FINGERPRINT-OBJ ,PLAYER>)>
@@ -3283,7 +3283,7 @@ does begin at home, as the saying goes. Not that I have anything to complain
 about. He always treated me right.\"" CR>)
 		      (T
 		       <TELL
-"\"I don't know nothing about no " D ,PRSI "\"." CR>)>)
+"\"I don't know nothing about no " D ,PRSI ".\"" CR>)>)
 	       (<VERB? SHOW CONFRONT>
 		<COND (<==? ,PRSI ,LAB-REPORT>
 		       <TELL

--- a/actions.zil
+++ b/actions.zil
@@ -2909,7 +2909,7 @@ Ms. Dunbar starts to cry and is embraced by Mr. Baxter." CR>)
 		       <TELL
 "Mr. Baxter and Ms. Dunbar are inside. Although you can't hear them, it's
 clear from their gestures that a serious argument is occurring. Dunbar appears
-very upset and breaks into tears. Baxter remains composed, but tense and 
+very upset and breaks into tears. Baxter remains composed, but tense and
 perhaps angry -- you can't be sure." CR>)
 		      (<G? ,SECRET-MEETING 0>
 		       <TELL

--- a/clock.zil
+++ b/clock.zil
@@ -60,7 +60,7 @@
 "Chief Inspector Klutz walks up to you, seemingly from out of nowhere.
 \"I'm sorry, Inspector, but your time is up here.  I'm sorry that you
 didn't have any more time to investigate the case.  Maybe next time...\"
-He escorts you to a waiting police car, in which  you go off into the
+He escorts you to a waiting police car, in which you go off into the
 sunset." CR>
 		<QUIT>)>
 	 <COND (<G? <SETG MOVES <+ ,MOVES 1>> 59>


### PR DESCRIPTION
These are the spelling fixes for Deadline from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.